### PR TITLE
Minor fixes and modifications to adapt tutorial for evomics2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ samtools index SRR341549.bam
 It's easy to use `minimap2` instead of `bwa mem`. This may help in some contexts, as it can be several fold faster with minimal reduction in alignment quality. In the case of these short reads, we'd use it as follows. The only major change from bwa mem is that we'll tell it we're working with short read data using `-ax sr`:
 
 ```bash
-minimap2 -ax sr -t $threads -R '@RG\tID:O104_H4\tSM:O104_H4' \
+minimap2 -ax sr -t 2 -R '@RG\tID:O104_H4\tSM:O104_H4' \
     E.coli_K12_MG1655.fa SRR341549_1.fastq  SRR341549_2.fastq \
     | samtools view -b - >SRR341549.raw.minimap2.bam
 sambamba sort SRR341549.raw.minimap2.bam


### PR DESCRIPTION
Main changes in Part 1- 
When using curl for the E. coli K12 reference, pointed it to an output `.fa` file to download it. 

When aligning against K12 reference
- specified number of threads to 2
- changed bwa-mem and minimap2 commands from needing fastq.gz files to fastq files

Main change in Part 2-
- provided an example vcffilter argument for the tabix+vcffilter command